### PR TITLE
readme: add more advanced case to the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ class Foo {
     const { #x: x } = this;
     console.log(x); // => 1
   }
+
+  equals({ #x: otherX }) {
+    const { #x: currentX } = this;
+    return currentX === otherX;
+  }
 }
 ```
 


### PR DESCRIPTION
The example described in the `equals` method makes use of parameter destructuring and also destructures something else than `this` as well.

It is non-obvious and I realized it when I tried to poke holes through the proposal.