### PR TITLE
DestructuringAssignmentEvaluation -> PropertyDestructuringAssignmentEvaluation

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -216,7 +216,7 @@ location: https://justin.ridgewell.name/proposal-destructuring-private/
 
       <emu-clause id="sec-runtime-semantics-propertydestructuringassignmentevaluation" type="sdo" aoid="PropertyDestructuringAssignmentEvaluation">
         <h1>
-          Runtime Semantics: DestructuringAssignmentEvaluation (
+          Runtime Semantics: PropertyDestructuringAssignmentEvaluation (
             _value_: unknown,
           )
         </h1>


### PR DESCRIPTION
I think this was just a typo. The AOID and id and note all refer to PropertyDestructuringAssignmentEvaluation, and also the semantics make sense for PropertyDestructuringAssignmentEvaluation.