### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # proposal-destructuring-private
 
-A proposal integrate private fields and destructuring.
+A proposal to integrate private fields and destructuring.
 
 ```js
 class Foo {


### PR DESCRIPTION
This fixes a typo in the opening sentence of the README.